### PR TITLE
feat(contact): add transport seam for active mailto flow

### DIFF
--- a/app/lib/contact/__tests__/transport.test.js
+++ b/app/lib/contact/__tests__/transport.test.js
@@ -1,0 +1,19 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { buildPortfolioMailtoUrl } = require('../mailtoTransportCore');
+
+describe('buildPortfolioMailtoUrl', () => {
+    it('builds a mailto URL with encoded subject and body', () => {
+        const redirectUrl = buildPortfolioMailtoUrl({
+            to: 'k8@k8port.io',
+            name: 'Jane Doe',
+            email: 'jane@example.com',
+            message: 'Hello world',
+        });
+
+        expect(redirectUrl).toContain('mailto:k8@k8port.io?');
+        expect(redirectUrl).toContain('subject=Portfolio%20Contact%20Form');
+        expect(redirectUrl).toContain(
+            'body=From%3A%20Jane%20Doe%20(jane%40example.com)%0A%0AHello%20world'
+        );
+    });
+});

--- a/app/lib/contact/mailtoTransportCore.js
+++ b/app/lib/contact/mailtoTransportCore.js
@@ -1,0 +1,10 @@
+function buildPortfolioMailtoUrl({ to, name, email, message }) {
+    const subject = encodeURIComponent('Portfolio Contact Form');
+    const body = encodeURIComponent(`From: ${name} (${email})\n\n${message}`);
+
+    return `mailto:${to}?subject=${subject}&body=${body}`;
+}
+
+module.exports = {
+    buildPortfolioMailtoUrl,
+};

--- a/app/lib/contact/transport.ts
+++ b/app/lib/contact/transport.ts
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { buildPortfolioMailtoUrl } = require('./mailtoTransportCore');
+
+export interface ContactSubmission {
+    name: string;
+    email: string;
+    message: string;
+}
+
+export interface ContactTransportResult {
+    ok: boolean;
+    redirectUrl?: string;
+    message?: string;
+    error?: string;
+}
+
+export interface ContactTransport {
+    submit(payload: ContactSubmission): Promise<ContactTransportResult>;
+}
+
+export class MailtoContactTransport implements ContactTransport {
+    constructor(private readonly to = 'k8@k8port.io') {}
+
+    async submit(payload: ContactSubmission): Promise<ContactTransportResult> {
+        const redirectUrl = buildPortfolioMailtoUrl({
+            to: this.to,
+            name: payload.name,
+            email: payload.email,
+            message: payload.message,
+        });
+
+        return {
+            ok: true,
+            redirectUrl,
+            message: 'Opening your email client...',
+        };
+    }
+}
+
+export function createContactTransport(): ContactTransport {
+    return new MailtoContactTransport();
+}

--- a/app/ui/collaborate/ContactForm.tsx
+++ b/app/ui/collaborate/ContactForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { createContactTransport } from '@/lib/contact/transport';
 
 interface ApiResponse {
     message?: string;
@@ -9,6 +10,7 @@ interface ApiResponse {
 
 // --- Main Form Component ----------------------------------------------
 export default function ContactForm() {
+    const transport = createContactTransport();
     const [status, setStatus] = useState<{
         loading: boolean;
         error?: string;
@@ -30,13 +32,23 @@ export default function ContactForm() {
         const handle = email;
 
         const message = fd.get('message')?.toString().trim() ?? '';
-        const payload = { name, method, handle, message };
+        const payload = { name, method, handle, message, email };
 
         try {
-            const subject = encodeURIComponent('Portfolio Contact Form');
-            const body = encodeURIComponent(`From: ${name} (${email})\n\n${message}`);
-            window.location.href = `mailto:k8@k8port.io?subject=${subject}&body=${body}`;
-            setStatus({ loading: false, success: 'Opening your email client...' });
+            const response = await transport.submit({
+                name: payload.name,
+                email: payload.email,
+                message: payload.message,
+            });
+            if (!response.ok || !response.redirectUrl) {
+                throw new Error(response.error || 'Failed to start contact flow');
+            }
+
+            window.location.href = response.redirectUrl;
+            setStatus({
+                loading: false,
+                success: response.message || 'Opening your email client...',
+            });
             form.reset();
         } catch (error: unknown) {
             setStatus({


### PR DESCRIPTION
## What changed\n- Added a contact transport seam for the active contact form flow.\n- Refactored the active form to call the seam while preserving current mailto behavior.\n- Added a focused regression test for encoded mailto URL generation.\n\n## Why\n- Establishes a deployment-agnostic adapter seam for issue #51 without changing user-facing behavior.\n- Creates a safe first increment before deprecating legacy/parallel contact paths.\n\n## Validation\n- pnpm test -- app/lib/contact/__tests__/transport.test.js\n- pnpm lint\n- pnpm build\n\n## Risk\n- Low: behavior remains mailto-based in the active UI path.\n\n## Rollback\n- Revert this PR to restore inline mailto URL construction in the form component.\n\nRefs #51