### PR TITLE
chore(contact): deprecate legacy server contact paths

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,52 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { Resend } from 'resend';
-import { EmailTemplate } from '@/ui/collaborate/EmailTemplate';
-import React from 'react';
+import { NextResponse } from 'next/server';
 
-const myVerifiedEmail = 'k8@k8port.io';
-
-function getResend(): Resend | null {
-    const apiKey = process.env.RESEND_API_KEY;
-    if (!apiKey) {
-        return null;
-    }
-
-    return new Resend(apiKey);
-}
-
-export async function POST(request: NextRequest) {
-    try {
-        const resend = getResend();
-        if (!resend) {
-            return NextResponse.json(
-                { error: 'Email service is not configured (missing RESEND_API_KEY).' },
-                { status: 500 }
-            );
-        }
-
-        const body = await request.json();
-        const { name, email, message } = body;
-
-        const { data, error } = await resend.emails.send({
-            from: 'Contact Form <hello@vibes.k8port.io>',
-            to: [myVerifiedEmail],
-            subject: 'New Message from Portfolio site contact form',
-            replyTo: email,
-            react: EmailTemplate({ name, email, message }) as React.ReactElement,
-        });
-
-        if (error) {
-            return NextResponse.json({ message: 'Failed to send email', error }, { status: 500 });
-        }
-
-        return NextResponse.json(
-            { message: 'Contact inquiry received and notification sent', data },
-            { status: 200 }
-        );
-    } catch (_error) {
-        return NextResponse.json(
-            { error: 'Failed to submit form inquiry.  Please try again.' },
-            { status: 500 }
-        );
-    }
+export async function POST() {
+    return NextResponse.json(
+        {
+            error: 'Legacy /api/contact route is deprecated. Use the active contact mailto transport flow.',
+        },
+        { status: 410 }
+    );
 }

--- a/app/lib/actions/contact.ts
+++ b/app/lib/actions/contact.ts
@@ -1,8 +1,4 @@
-// app/actions/contact.ts
 'use server';
-
-import { getEmailAdapter } from '@/lib/email';
-import type { Mail } from '@/lib/email';
 
 interface State {
     success: boolean;
@@ -10,45 +6,9 @@ interface State {
 }
 
 export async function submitContact(_prevState: State, formData: FormData): Promise<State> {
-    console.log('submitContact invoked', formData);
-    const firstname = formData.get('firstname')?.toString().trim() ?? '';
-    const lastname = formData.get('lastname')?.toString().trim() ?? '';
-    const preference = (formData.get('preference') as string | null) ?? 'email';
-    const phone = formData.get('phone')?.toString().trim() ?? '';
-    const email = formData.get('email')?.toString().trim() ?? '';
-    const whatsapp = formData.get('whatsapp')?.toString().trim() ?? '';
-    const message = formData.get('message')?.toString().trim() ?? '';
-
-    /* -------- basic validation -------- */
-    if (!firstname || !preference) {
-        if (preference === 'email') {
-            if (!email) return { success: false, error: 'Email address required.' };
-        } else if (preference === 'text') {
-            if (!phone) return { success: false, error: 'Phone number required.' };
-        } else if (preference === 'whatsapp') {
-            if (!whatsapp) return { success: false, error: 'WhatsApp handle required.' };
-        }
-        return { success: false, error: 'First name and communication preference are required.' };
-    } else if (preference === 'email' && !email)
-        return { success: false, error: 'Email address required.' };
-    else if (preference === 'text' && !phone)
-        return { success: false, error: 'Phone number required.' };
-    else if (preference === 'whatsapp' && !whatsapp)
-        return { success: false, error: 'WhatsApp handle required.' };
-
-    /* -------- Notify site owner by default adapter -------- */
-    const adminMail: Mail = {
-        to: process.env.MAIL_TO!,
-        subject: 'New inquiry from ${firstname}',
-        html: `<p><strong>${firstname}</strong> wrote:</p><blockquote>${message || 'nothing'}</blockquote><p>Contact via: ${email} || ${phone} || ${whatsapp}</p>`,
-        text: `${firstname} ${lastname} wrote: ${message || 'nothing'}\n\nContact Via: ${email} || ${phone} || ${whatsapp}`,
+    void formData;
+    return {
+        success: false,
+        error: 'Legacy server contact action is deprecated. Use the active contact mailto transport flow.',
     };
-
-    const adminAdapter = getEmailAdapter();
-    const adminResult = await adminAdapter.send(adminMail);
-    if (!adminResult.ok) {
-        return { success: false, error: `Notification failed: ${adminResult.error}` };
-    }
-
-    return { success: true };
 }

--- a/app/ui/collaborate/ContactForm_v1.tsx
+++ b/app/ui/collaborate/ContactForm_v1.tsx
@@ -8,6 +8,9 @@ interface ApiResponse {
     error?: string;
 }
 
+// Deprecated legacy component. Kept temporarily for reference while the active
+// contact flow uses MailtoContactTransport via ContactForm.tsx.
+
 // --- Main Form Component ----------------------------------------------
 export default function ContactForm() {
     const [preference, setPreference] = useState<'email' | 'text' | 'whatsapp'>('email');
@@ -65,10 +68,11 @@ export default function ContactForm() {
 
     if (status.success) {
         return (
-        <div className="text-brand-secondary font-lobster font-semibold text-center">
-            Thanks for your inquiry! I&apos;ll be in touch soon!
-        </div>
-    )} else {
+            <div className="text-brand-secondary font-lobster font-semibold text-center">
+                Thanks for your inquiry! I&apos;ll be in touch soon!
+            </div>
+        );
+    } else {
         return (
             <form
                 onSubmit={handleSubmit}
@@ -216,5 +220,6 @@ export default function ContactForm() {
                 {/* Error Message */}
                 {status.error && <p className="text-collection-alizarincrimson">{status.error}</p>}
             </form>
-    )};
+        );
+    }
 }


### PR DESCRIPTION
## What changed
- Deprecated legacy /api/contact route with explicit 410 response.
- Deprecated legacy server action contact entrypoint with stable error contract.
- Marked ContactForm_v1 as deprecated reference-only component.

## Why
- Aligns contact architecture around one active path and removes ambiguity from unused server-side alternatives.
- Keeps deprecation explicit while avoiding behavior changes in the active form flow.

## Validation
- pnpm test -- app/lib/contact/__tests__/transport.test.js
- pnpm lint
- pnpm build

## Risk
- Low: active user-facing contact path remains unchanged.

## Rollback
- Revert this PR to restore previous legacy route/action behavior.

Refs #51
