### PR TITLE
fix(contact): interpolate sender name in mailto subject

### DIFF
--- a/app/lib/contact/__tests__/transport.test.js
+++ b/app/lib/contact/__tests__/transport.test.js
@@ -11,7 +11,8 @@ describe('buildPortfolioMailtoUrl', () => {
         });
 
         expect(redirectUrl).toContain('mailto:k8@k8port.io?');
-        expect(redirectUrl).toContain('subject=Portfolio%20Contact%20Form');
+        expect(redirectUrl).toContain('subject=New%20inquiry%20from%20Jane%20Doe');
+        expect(redirectUrl).not.toContain('%24%7Bname%7D');
         expect(redirectUrl).toContain(
             'body=From%3A%20Jane%20Doe%20(jane%40example.com)%0A%0AHello%20world'
         );

--- a/app/lib/contact/mailtoTransportCore.js
+++ b/app/lib/contact/mailtoTransportCore.js
@@ -1,5 +1,5 @@
 function buildPortfolioMailtoUrl({ to, name, email, message }) {
-    const subject = encodeURIComponent('Portfolio Contact Form');
+    const subject = encodeURIComponent(`New inquiry from ${name}`);
     const body = encodeURIComponent(`From: ${name} (${email})\n\n${message}`);
 
     return `mailto:${to}?subject=${subject}&body=${body}`;


### PR DESCRIPTION
## What changed
- Updated contact mailto subject builder to interpolate sender name.
- Added regression coverage to ensure dynamic subject encoding and prevent literal template placeholder regressions.

## Why
- Fixes issue #50 where subject text could fail to reflect sender identity.

## Validation
- pnpm test -- app/lib/contact/__tests__/transport.test.js
- pnpm lint
- pnpm build

## Risk
- Low: only subject string composition changed in active mailto transport flow.

## Rollback
- Revert this PR to restore prior static subject behavior.

closes #50