### PR TITLE
fix(contact): fallback subject when sender name is blank

### DIFF
--- a/app/lib/contact/__tests__/transport.test.js
+++ b/app/lib/contact/__tests__/transport.test.js
@@ -17,4 +17,15 @@ describe('buildPortfolioMailtoUrl', () => {
             'body=From%3A%20Jane%20Doe%20(jane%40example.com)%0A%0AHello%20world'
         );
     });
+
+    it('uses fallback sender label when name is blank', () => {
+        const redirectUrl = buildPortfolioMailtoUrl({
+            to: 'k8@k8port.io',
+            name: '   ',
+            email: 'jane@example.com',
+            message: 'Hello world',
+        });
+
+        expect(redirectUrl).toContain('subject=New%20inquiry%20from%20anonymous%20sender');
+    });
 });

--- a/app/lib/contact/mailtoTransportCore.js
+++ b/app/lib/contact/mailtoTransportCore.js
@@ -1,5 +1,6 @@
 function buildPortfolioMailtoUrl({ to, name, email, message }) {
-    const subject = encodeURIComponent(`New inquiry from ${name}`);
+    const senderName = name?.trim() || 'anonymous sender';
+    const subject = encodeURIComponent(`New inquiry from ${senderName}`);
     const body = encodeURIComponent(`From: ${name} (${email})\n\n${message}`);
 
     return `mailto:${to}?subject=${subject}&body=${body}`;


### PR DESCRIPTION
## What changed
- Added sender-name fallback for contact subject generation when name is blank.
- Added regression coverage for blank-name subject behavior.

## Why
- Hardens issue #50 fix against empty-name edge cases while preserving current flow.

## Validation
- pnpm test -- app/lib/contact/__tests__/transport.test.js
- pnpm lint
- pnpm build

## Risk
- Low: change is limited to subject text formatting.

## Rollback
- Revert this PR to restore previous subject behavior.

Refs #50