### PR TITLE
fix: migrate contact mailto core to ESM and stabilize icons

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -42,7 +42,7 @@ jobs:
               run: pnpm build
 
             - name: Run tests
-              run: pnpm test
+              run: pnpm test:ci
 
             - name: Setup Pages
               if: github.event_name == 'push'

--- a/app/lib/actions/__tests__/blendMode.test.ts
+++ b/app/lib/actions/__tests__/blendMode.test.ts
@@ -1,0 +1,11 @@
+import { getBlendMode } from '@/lib/actions/blendMode';
+
+describe('getBlendMode', () => {
+    it('returns normalized class for valid blend mode', () => {
+        expect(getBlendMode('overlay')).toBe('mix-blend-overlay');
+    });
+
+    it('falls back to normal for invalid mode', () => {
+        expect(getBlendMode('not-a-mode')).toBe('mix-blend-normal');
+    });
+});

--- a/app/lib/actions/getFontAwesomeIcon.ts
+++ b/app/lib/actions/getFontAwesomeIcon.ts
@@ -29,6 +29,10 @@ import {
     FaWindows,
     FaHammer,
     FaGithubAlt,
+    FaUser,
+    FaArrowRight,
+    FaLinkedin,
+    FaWhatsapp,
 } from 'react-icons/fa';
 import {
     SiTypescript,
@@ -87,10 +91,6 @@ import {
     FaScrewdriverWrench,
     FaCompassDrafting,
     FaPersonDigging,
-    FaUserAstronaut,
-    FaArrowRightLong,
-    FaLinkedin,
-    FaWhatsapp,
 } from 'react-icons/fa6';
 import { GiThink, GiTeacher, GiStrongMan } from 'react-icons/gi';
 import { TbMath } from 'react-icons/tb';
@@ -105,7 +105,7 @@ import {
 import { FcCollaboration } from 'react-icons/fc';
 import { PiStudent, PiFileCpp } from 'react-icons/pi';
 import { VscAzure } from 'react-icons/vsc';
-import { IconType } from 'react-icons';
+import type { IconType } from 'react-icons';
 import { BsMegaphone } from 'react-icons/bs';
 
 export const iconMap: Record<string, IconType> = {
@@ -214,8 +214,8 @@ export const iconMap: Record<string, IconType> = {
     Download: FiDownloadCloud,
     Phone: MdOutlinePhone,
     Contact: BsMegaphone,
-    User: FaUserAstronaut,
-    'Right Arrow': FaArrowRightLong,
+    User: FaUser,
+    'Right Arrow': FaArrowRight,
     LinkedIn: FaLinkedin,
     GitHub: FaGithubAlt,
     WhatsApp: FaWhatsapp,

--- a/app/lib/contact/__tests__/transport.test.ts
+++ b/app/lib/contact/__tests__/transport.test.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
-const { buildPortfolioMailtoUrl } = require('../mailtoTransportCore');
+import { buildPortfolioMailtoUrl } from '../mailtoTransportCore';
 
 describe('buildPortfolioMailtoUrl', () => {
     it('builds a mailto URL with encoded subject and body', () => {

--- a/app/lib/contact/mailtoTransportCore.ts
+++ b/app/lib/contact/mailtoTransportCore.ts
@@ -1,11 +1,19 @@
-function buildPortfolioMailtoUrl({ to, name, email, message }) {
+interface BuildPortfolioMailtoUrlInput {
+    to: string;
+    name: string;
+    email: string;
+    message: string;
+}
+
+export function buildPortfolioMailtoUrl({
+    to,
+    name,
+    email,
+    message,
+}: BuildPortfolioMailtoUrlInput): string {
     const senderName = name?.trim() || 'anonymous sender';
     const subject = encodeURIComponent(`New inquiry from ${senderName}`);
     const body = encodeURIComponent(`From: ${name} (${email})\n\n${message}`);
 
     return `mailto:${to}?subject=${subject}&body=${body}`;
 }
-
-module.exports = {
-    buildPortfolioMailtoUrl,
-};

--- a/app/lib/contact/transport.ts
+++ b/app/lib/contact/transport.ts
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
-const { buildPortfolioMailtoUrl } = require('./mailtoTransportCore');
+import { buildPortfolioMailtoUrl } from './mailtoTransportCore';
 
 export interface ContactSubmission {
     name: string;

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,0 +1,27 @@
+export default {
+    preset: 'ts-jest/presets/default-esm',
+    testEnvironment: 'jsdom',
+    roots: ['<rootDir>/app'],
+    testMatch: ['**/__tests__/**/*.test.(ts|tsx|js|jsx)'],
+    transform: {
+        '^.+\\.(ts|tsx)$': [
+            'ts-jest',
+            {
+                useESM: true,
+                tsconfig: {
+                    jsx: 'react-jsx',
+                },
+            },
+        ],
+    },
+    extensionsToTreatAsEsm: ['.ts', '.tsx'],
+    moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/app/$1',
+        '\\.(css|less|sass|scss)$': '<rootDir>/__mocks__/styleMock.js',
+        '\\.(gif|ttf|eot|svg|png|jpg|jpeg|webp|avif)$': '<rootDir>/__mocks__/fileMock.js',
+        '^next/font/(.*)$': '<rootDir>/__mocks__/nextFontMock.js',
+    },
+    setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+    clearMocks: true,
+    collectCoverageFrom: ['app/**/*.{ts,tsx}', '!app/**/*.d.ts', '!app/**/__tests__/**'],
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "format:browns": "prettier --write 'app/styles/colors/neutrals/browns.ts'",
         "test:clear": "jest --clearCache",
         "test": "jest",
+        "test:ci": "jest --ci --runInBand",
         "test:watch": "jest --watch",
         "test:coverage": "jest --coverage"
     },


### PR DESCRIPTION
## Summary
- migrate contact mailto transport core from CommonJS to TypeScript ESM
- update transport and tests to import the new module path
- harden icon registry mappings to stable react-icons/fa exports for user/social arrow icons
- add baseline test scaffolding files (jest.setup.ts, blendMode test) and test:ci script

## Why
- resolves runtime errors from browser/Next ESM bundles referencing module.exports
- prevents stale import traces to deleted .js transport module
- keeps baseline test setup aligned with issue #55 branch work

## Validation
- pnpm lint
- jest -- app/lib/contact/__tests__/transport.test.ts
- pnpm build
