### PR TITLE
chore: tighten ESLint unused-vars and explicit-any rules

### DIFF
--- a/app/lib/actions/getFontAwesomeIcon.ts
+++ b/app/lib/actions/getFontAwesomeIcon.ts
@@ -83,7 +83,7 @@ import {
 import { IoLogoJavascript } from 'react-icons/io5';
 import { FiDownloadCloud } from 'react-icons/fi';
 import { DiMongodb, DiDjango, DiMysql, DiPostgresql, DiRuby } from 'react-icons/di';
-import { MdOutlineViewKanban, MdOutlinePhone, MdOutlineCloudDownload } from 'react-icons/md';
+import { MdOutlineViewKanban, MdOutlinePhone } from 'react-icons/md';
 import {
     FaBusinessTime,
     FaGolang,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,8 +43,16 @@ const eslintConfig = [
 
             // ✅ Keep necessary overrides and code quality rules:
             '@next/next/no-img-element': 'off',
-            '@typescript-eslint/no-unused-vars': 'off',
-            '@typescript-eslint/no-explicit-any': 'off',
+            '@typescript-eslint/no-unused-vars': [
+                'warn',
+                {
+                    argsIgnorePattern: '^_',
+                    varsIgnorePattern: '^_',
+                    caughtErrorsIgnorePattern: '^_',
+                    ignoreRestSiblings: true,
+                },
+            ],
+            '@typescript-eslint/no-explicit-any': 'warn',
             'react/react-in-jsx-scope': 'off',
             'no-console': ['error', { allow: ['warn', 'error'] }],
         },

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,4 +1,4 @@
-export default {
+const config = {
     preset: 'ts-jest/presets/default-esm',
     testEnvironment: 'jsdom',
     roots: ['<rootDir>/app'],
@@ -25,3 +25,5 @@ export default {
     clearMocks: true,
     collectCoverageFrom: ['app/**/*.{ts,tsx}', '!app/**/*.d.ts', '!app/**/__tests__/**'],
 };
+
+export default config;


### PR DESCRIPTION
## Summary
- tighten ESLint rules for TypeScript hygiene with a staged rollout
- set `@typescript-eslint/no-unused-vars` to `warn` with practical ignore patterns (`^_` for args/vars/caught errors)
- set `@typescript-eslint/no-explicit-any` to `warn`
- clean up lint noise introduced by recent changes (`jest.config.mjs` default export style, remove unused icon import)

## Why
- issue #56 requires tightening policy without destabilizing delivery flow
- warning-level rollout exposes hotspots now, enabling incremental hardening to `error` in follow-up PRs

## Current Warning Inventory
- total warnings: 31
- by rule:
  - `@typescript-eslint/no-unused-vars`: 23
  - `@typescript-eslint/no-explicit-any`: 8
- top files:
  - `app/lib/email/index.ts`: 7
  - `app/ui/background/Animate.tsx`: 3
  - `app/ui/collaborate/ContactForm_v1.tsx`: 3
  - `app/data/EUROPEAN_MUSES.ts`: 2
  - `app/lib/hooks/useBreakpointDebug.ts`: 2

## Validation
- `pnpm exec eslint . --ext .js,.jsx,.ts,.tsx`
- `pnpm test:ci`

Closes #56
