### PR TITLE
docs: refresh README and testing strategy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,101 @@
 # k8port.github.io
 
-[Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+Personal portfolio site built with Next.js App Router, TypeScript, Tailwind CSS, and static export deployment.
 
-## Getting Started
+## Stack
 
-First, run the development server:
+- Next.js 15 (App Router)
+- React 19
+- TypeScript 5
+- Tailwind CSS 4
+- ESLint 9 + Prettier
+- Jest + Testing Library
+- pnpm
+
+## Prerequisites
+
+- Node.js >= 22 and < 26
+- Corepack enabled (recommended)
+
+## Local setup
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+corepack enable
+corepack prepare pnpm@10.10.0 --activate
+pnpm install
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Run locally
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+pnpm dev
+```
 
-## Learn More
+App runs at http://localhost:3000.
 
-To learn more about Next.js, take a look at the following resources:
+## Commands
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+- `pnpm dev`: start local dev server
+- `pnpm lint`: run ESLint
+- `pnpm lint:fix`: auto-fix lint issues when possible
+- `pnpm test`: run Jest tests
+- `pnpm test:ci`: run Jest in CI mode (`--ci --runInBand`)
+- `pnpm test:coverage`: run tests with coverage output
+- `pnpm build`: production build (static export enabled)
+- `pnpm start`: serve production build output
+- `pnpm format`: run Prettier for app/styles files
 
-Check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## Deployment model
 
-## Deploy on Vercel
+Deployment target is GitHub Pages via GitHub Actions workflow in [.github/workflows/nextjs.yml](.github/workflows/nextjs.yml).
 
-The easiest way to deploy Next.js is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+Key behavior:
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- `next.config.ts` sets `output: 'export'` and `images.unoptimized: true`
+- `pnpm build` produces static export artifacts in `out/`
+- Workflow uploads `out/` on pushes to `main`
+
+## Testing and quality gates
+
+Pull requests to `main` run the workflow job that executes:
+
+1. `pnpm install`
+2. `pnpm build`
+3. `pnpm test:ci`
+
+Keep local checks aligned with CI:
+
+```bash
+pnpm lint
+pnpm test:ci
+pnpm build
+```
+
+## Contributor workflow
+
+1. Create a branch from `main`
+2. Implement a scoped change
+3. Run local checks: lint, tests, build
+4. Push branch and open PR into `main`
+5. Merge after CI is green
+
+Example:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git checkout -b feat/your-change
+
+pnpm lint
+pnpm test:ci
+pnpm build
+
+git add -A
+git commit -m "feat: your change summary"
+git push -u origin feat/your-change
+```
+
+## Notes
+
+- The legacy API contact route is intentionally deprecated; current contact flow uses mailto transport.
+- Jest config is ESM-based in [jest.config.mjs](jest.config.mjs).

--- a/testing-strategy.md
+++ b/testing-strategy.md
@@ -1,130 +1,75 @@
-# Unit Testing Strategy
+# Testing Strategy
 
-Following is a comprehensive unit testing strategy for this application broken down into different aspects to be tested:
+This document reflects the current implemented baseline and CI-enforced checks.
 
-## Component Testing
+## Current baseline
 
-    Test individual React components for:
+- Test runner: Jest 29
+- Environment: `jsdom`
+- Transform: `ts-jest` with ESM preset
+- Assertions: `@testing-library/jest-dom`
+- Location pattern: `app/**/__tests__/**/*.test.(ts|tsx|js|jsx)`
 
-      * Rendering without crashing
-      * Proper display of props
-      * State management
-      * User interactions
-      * Component lifecycle behaviors
+Config source:
 
-An example unit test using Jest and React Testing Library:
+- [jest.config.mjs](jest.config.mjs)
+- [jest.setup.ts](jest.setup.ts)
 
-    ```typescript
-    import { render, screen, fireEvent } from '@testing-library/react'
-    import Component from './Component'
+## Existing test coverage (baseline)
 
-    describe('Component', () => {
-        test('renders correctly with default props', () => {
-        render(<Component />)
-        expect(screen.getByRole('heading')).toBeInTheDocument()
-    })
+Current committed baseline tests include:
 
-    test('handles user interaction correctly', () => {
-        render(<Component />)
-        const button = screen.getByRole('button')
-        fireEvent.click(button)
-        expect(screen.getByText('Changed State')).toBeInTheDocument()
-    })
-    ```
+- page render smoke check: [app/__tests__/page.test.tsx](app/__tests__/page.test.tsx)
+- blend mode helper behavior: [app/lib/actions/__tests__/blendMode.test.ts](app/lib/actions/__tests__/blendMode.test.ts)
+- contact mailto transport URL behavior: [app/lib/contact/__tests__/transport.test.ts](app/lib/contact/__tests__/transport.test.ts)
 
-## Data Loading and Processing
+These validate basic rendering and key utility/action behavior without introducing fragile snapshot coupling.
 
-    Using JSON data, test:
+## CI-enforced checks
 
-    * Correct data loading
-    * Data transformation functions
-    * Error handling when data is malformed
-    * Edge cases in data processing
+PRs to `main` run tests in GitHub Actions:
 
-Example unit test for data processing:
+- workflow: [.github/workflows/nextjs.yml](.github/workflows/nextjs.yml)
+- command: `pnpm test:ci`
 
-    ```typescript
-    import { processData } from './dataUtils'
-    import mockData from './__mocks__/mockData.json'
+`test:ci` currently maps to:
 
-    describe('Data Processing', () => {
-        test('processes valid JSON data correctly', () => {
-        const result = processData(mockData)
-        expect(result).toMatchSnapshot()
-    })
+```bash
+jest --ci --runInBand
+```
 
-    test('handles empty data gracefully', () => {
-        const result = processData({})
-        expect(result).toEqual([])
-    })
-    ```
+## Local developer workflow
 
-## UI State Management
+Recommended local verification before opening a PR:
 
-    _Test any state management logic_:
+```bash
+pnpm lint
+pnpm test:ci
+pnpm build
+```
 
-      - Initial state setup
-      - State updates
-      - Side effects
-      - Error states
+For active test development:
 
-Example unit test for utility functions:
+```bash
+pnpm test:watch
+```
 
-    ```typescript
-    import { formatDate, calculateTotal } from './utils'
+For cache resets while troubleshooting:
 
-    describe('Utility Functions', () => {
-        test('formatDate formats dates correctly', () => {
-        const date = new Date('2024-02-08')
-        expect(formatDate(date)).toBe('Feb 8, 2024')
-    })
+```bash
+pnpm test:clear
+```
 
-    test('calculateTotal handles different number formats', () => {
-        expect(calculateTotal([1.99, 2.50, 3])).toBe(7.49)
-    })
-    ```
+## Near-term test plan
 
-## Accessibility Testing
+1. Add focused tests for contact form state transitions and submission outcomes (success/error).
+2. Add tests for route and transport boundaries where behavior was recently refactored.
+3. Expand utility-level tests for data adapters and rendering helpers with deterministic fixtures.
+4. Keep tests behavior-oriented and avoid broad snapshot-only coverage.
 
-    Include tests for accessibility:
+## Quality principles
 
-    ```typescript
-    import { render } from '@testing-library/react'
-    import { axe } from 'jest-axe'
-
-    describe('Accessibility', () => {
-        test('has no accessibility violations', async () => {
-            const { container } = render(<Component />)
-            const results = await axe(container)
-            expect(results).toHaveNoViolations()
-        })
-    })
-    ```
-
-## Responsive Design
-
-    Test component behavior at different viewport sizes:
-
-    ```typescript
-    import { render } from '@testing-library/react'
-    import { act } from 'react-dom/test-utils'
-
-    describe('Responsive Design', () => {
-        test('adapts to mobile viewport', () => {
-            global.innerWidth = 375
-            act(() => {
-                global.dispatchEvent(new Event('resize'))
-            })
-            const { container } = render(<Component />)
-            expect(container.querySelector('.mobile-class')).toBeInTheDocument()
-        })
-    ```
-
-## Key Testing Principles to Follow
-
-    - Write tests that mirror real usage patterns
-    - Test both success and error paths
-    - Keep tests isolated and independent
-    - Use meaningful test descriptions
-    - Mock external dependencies appropriately
-    - Test edge cases and boundary conditions
+1. Prefer deterministic tests over timing-dependent assertions.
+2. Keep each test scoped to one behavior.
+3. Mock external boundaries only (network/services), not internal logic under test.
+4. Update docs and tests together when behavior changes.


### PR DESCRIPTION
## Summary
- replace boilerplate README with repository-accurate setup, scripts, deployment, and contributor workflow
- align testing strategy doc with implemented Jest baseline and CI-enforced checks
- document local verification flow matching CI (`lint`, `test:ci`, `build`)

## Details
- README now reflects:
  - Node and pnpm prerequisites
  - real script usage from `package.json`
  - static export and GitHub Pages deployment model (`output: 'export'`, `out/` artifact)
  - contributor branch/PR workflow
- testing strategy now reflects:
  - actual Jest config and scope
  - existing baseline tests in repo
  - near-term test expansion plan tied to current architecture

## Validation
- command pnpm run test:ci
- command pnpm run build

Closes #58
